### PR TITLE
Use memcpy to copy data

### DIFF
--- a/DebugGUI/src/DebugGUI.h
+++ b/DebugGUI/src/DebugGUI.h
@@ -19,8 +19,7 @@ namespace o2::framework {
 void default_error_callback(int, const char*);
 
 void* initGUI(const char* name, decltype(default_error_callback) = nullptr);
-bool pollGUI(void* context, std::function<void(void)> guiCallback);
-void getFrameJSON(void *data, std::ostream& json_data);
+bool pollGUI(void *context, std::function<void(void)> guiCallback);
 void getFrameRaw(void *data, void **raw_data, int *size);
 bool pollGUIPreRender(void* context, float delta);
 void* pollGUIRender(std::function<void(void)> guiCallback);


### PR DESCRIPTION
Next step will be to allow to use your own callback, rather than memcpy so that we can send the data directly without having to copy it first.